### PR TITLE
Fix the inconsistent version number of dependency

### DIFF
--- a/pseidon-kafka/project.clj
+++ b/pseidon-kafka/project.clj
@@ -8,7 +8,7 @@
                  [org.clojure/core.async "LATEST"]
                  [kafka-clj "1.0.3-SNAPSHOT"]
                  [midje "1.6-alpha2" :scope "test"]
-                 [pseidon "0.4.4-SNAPSHOT" :scope "provided"]
+                 [pseidon "0.5.1-SNAPSHOT" :scope "provided"]
                  [com.taoensso/nippy "2.5.2"]
                  [night-vision "0.1.0-SNAPSHOT" :scope "test"]
                  [net.sf.jopt-simple/jopt-simple "3.2" :scope "provided"]

--- a/pseidon/project.clj
+++ b/pseidon/project.clj
@@ -7,7 +7,7 @@
                  [org.clojure/clojure "1.6.0"]
                  [thread-exec "0.2.0-SNAPSHOT"]
                  [com.taoensso/nippy "2.4.1"] 
-                 [net.openhft/chronicle "2.1-SNAPSHOT"]
+                 [net.openhft/chronicle "3.1.1"]
                  [goat "0.1.0-SNAPSHOT"]
                  [commons-net "3.2"]
                  [commons-lang "2.6"]


### PR DESCRIPTION
Due to the inconsistent version number of dependency, I cannot compile pseidon-logcollector/pseidon-logcollector correctly. Just fix this version number.
